### PR TITLE
Remove pages and fix inventory error

### DIFF
--- a/commands/cultivation/craft.js
+++ b/commands/cultivation/craft.js
@@ -247,52 +247,14 @@ module.exports = {
         // Tạo các trang với thông tin chi tiết
         const pages = [];
         
-        // Page 1: Tổng quan
-        const overviewEmbed = new EmbedBuilder()
-            .setTitle('🧪 Craft Recipes - Tu Tiên')
-            .setDescription('**Hệ thống chế tạo vật phẩm tu tiên (chỉ CRAFT)**')
-            .setColor(0x9932cc)
-            .setTimestamp()
-            .setFooter({ 
-                text: `Trang 1/3 • Yêu cầu bởi ${message.author.username}`, 
-                iconURL: message.author.displayAvatarURL() 
-            })
-            .addFields([
-                {
-                    name: '🔨 CRAFT (Chế tạo)',
-                    value: `**${Object.keys(CRAFT_RECIPES).length} công thức craft:**\n` +
-                           '• **Đan dược:** d1, d2, d3, d4 (từ nguyên liệu + đan phương + đan lò)\n' +
-                           '• **Linh thạch:** lt2, lt3, lt4 (từ linh thạch thấp hơn + tụ linh thạch)\n' +
-                           '• **Tỉ lệ thành công:** 50%',
-                    inline: false
-                },
-                {
-                    name: '💡 Cách sử dụng',
-                    value: '• `!craft <item>` - Chế tạo vật phẩm (50% thành công)\n' +
-                           '• `!craft recipes` - Xem tất cả công thức\n' +
-                           '• `!farm` - Thu thập nguyên liệu cơ bản (1-7, lt1)\n' +
-                           '• `!shop` - Mua đan phương, đan lò, tụ linh thạch',
-                    inline: false
-                },
-                {
-                    name: '📖 Navigation',
-                    value: '• **Trang 1:** Tổng quan hệ thống\n' +
-                           '• **Trang 2:** CRAFT - Đan dược (d1-d4)\n' +
-                           '• **Trang 3:** CRAFT - Linh thạch (lt2-lt4) & Hướng dẫn\n\n' +
-                           '🎮 **Dùng nút bên dưới để chuyển trang!**',
-                    inline: false
-                }
-            ]);
-        pages.push(overviewEmbed);
-
-        // Page 2: CRAFT - Đan dược
+        // Page 1: CRAFT - Đan dược
         const craftPillsEmbed = new EmbedBuilder()
             .setTitle('🔨 CRAFT - Đan dược')
             .setDescription('**Chế tạo đan dược từ nguyên liệu + đan phương + đan lò**')
             .setColor(0x0080ff)
             .setTimestamp()
             .setFooter({ 
-                text: `Trang 2/3 • Yêu cầu bởi ${message.author.username}`, 
+                text: `Trang 1/2 • Yêu cầu bởi ${message.author.username}`, 
                 iconURL: message.author.displayAvatarURL() 
             });
 
@@ -339,14 +301,14 @@ module.exports = {
         });
         pages.push(craftPillsEmbed);
 
-        // Page 3: CRAFT - Linh thạch & Hướng dẫn
+        // Page 2: CRAFT - Linh thạch & Hướng dẫn
         const craftStonesEmbed = new EmbedBuilder()
             .setTitle('🔨 CRAFT - Linh thạch & Hướng dẫn')
             .setDescription('**Chế tạo linh thạch cao cấp và hướng dẫn sử dụng**')
             .setColor(0xff6600)
             .setTimestamp()
             .setFooter({ 
-                text: `Trang 3/3 • Yêu cầu bởi ${message.author.username}`, 
+                text: `Trang 2/2 • Yêu cầu bởi ${message.author.username}`, 
                 iconURL: message.author.displayAvatarURL() 
             });
 
@@ -425,26 +387,7 @@ module.exports = {
                     .setDisabled(currentPage === totalPages - 1)
             );
             
-            // Jump to overview (always show except on page 1)
-            if (currentPage !== 0) {
-                buttons.push(
-                    new ButtonBuilder()
-                        .setCustomId('craft_home')
-                        .setLabel('🏠 Tổng quan')
-                        .setStyle(ButtonStyle.Success)
-                );
-            }
-            
-            // Quick navigation to specific sections
-            if (totalPages === 3 && currentPage === 0) {
-                // Add quick access button on overview page
-                buttons.push(
-                    new ButtonBuilder()
-                        .setCustomId('craft_jump')
-                        .setLabel('🚀 Chuyển nhanh')
-                        .setStyle(ButtonStyle.Secondary)
-                );
-            }
+
             
             return new ActionRowBuilder().addComponents(buttons);
         };
@@ -468,20 +411,6 @@ module.exports = {
                 currentPage--;
             } else if (interaction.customId === 'craft_next' && currentPage < pages.length - 1) {
                 currentPage++;
-            } else if (interaction.customId === 'craft_home') {
-                currentPage = 0;
-            } else if (interaction.customId === 'craft_jump') {
-                // Show quick navigation info
-                                        await interaction.followUp({
-                            content: '🚀 **Chuyển nhanh đến trang bằng nút navigation:**\n\n' +
-                                     '📖 **Mục lục 3 trang:**\n' +
-                                     '• **Trang 1:** 🏠 Tổng quan hệ thống\n' +
-                                     '• **Trang 2:** 🔨 CRAFT Đan dược (d1-d4)\n' +
-                                     '• **Trang 3:** 🔨 CRAFT Linh thạch (lt2-lt4) & Hướng dẫn\n\n' +
-                                     '💡 **Dùng nút `◀ Trước` và `Sau ▶` để chuyển trang**',
-                            ephemeral: true
-                        });
-                return; // Don't update main message
             }
 
             await interaction.update({

--- a/commands/cultivation/inventory.js
+++ b/commands/cultivation/inventory.js
@@ -187,7 +187,7 @@ module.exports = {
                 // Check for shop items
                 shopItems.forEach(item => {
                     const shopData = SHOP_ITEMS[item.itemId];
-                    if (shopData && item.quantity > 0) {
+                    if (shopData && shopData.icon && item.quantity > 0) {
                         shopDisplay.push(`${shopData.icon}${item.quantity}`);
                     }
                 });

--- a/commands/cultivation/shop.js
+++ b/commands/cultivation/shop.js
@@ -207,7 +207,7 @@ module.exports = {
             .setColor(0xffd700)
             .setTimestamp()
             .setFooter({ 
-                text: `Trang 1/4 • ${message.author.username}`, 
+                text: `Trang 1/2 • ${message.author.username}`, 
                 iconURL: message.author.displayAvatarURL() 
             })
             .addFields([
@@ -250,7 +250,7 @@ module.exports = {
             .setColor(0xff8800)
             .setTimestamp()
             .setFooter({ 
-                text: `Trang 2/4 • ${message.author.username}`, 
+                text: `Trang 2/2 • ${message.author.username}`, 
                 iconURL: message.author.displayAvatarURL() 
             });
 
@@ -285,86 +285,7 @@ module.exports = {
         });
         pages.push(craftingEmbed);
 
-        // Page 3: Linh đan
-        const pillsEmbed = new EmbedBuilder()
-            .setTitle('🟢 Linh Đan - Tăng EXP & Đột Phá')
-            .setDescription('**Linh đan giúp tăng EXP tu luyện và tỉ lệ đột phá**')
-            .setColor(0x44ff44)
-            .setTimestamp()
-            .setFooter({ 
-                text: `Trang 3/4 • ${message.author.username}`, 
-                iconURL: message.author.displayAvatarURL() 
-            });
 
-        Object.entries(SHOP_ITEMS).filter(([id, item]) => id.startsWith('ld')).forEach(([id, item]) => {
-            // Handle items without price
-            if (!item.price || !item.currency) {
-                pillsEmbed.addFields({
-                    name: `${item.icon} ${item.name} 🚧`,
-                    value: `**Giá:** Chưa có giá (sắp ra mắt)\n` +
-                           `**Mô tả:** ${item.description}\n` +
-                           `**Trạng thái:** Đang phát triển`,
-                    inline: true
-                });
-                return;
-            }
-
-            const currencyData = SPIRIT_STONES[item.currency];
-            const userHas = userCurrency[item.currency] || 0;
-            const canAfford = userHas >= item.price;
-            
-            pillsEmbed.addFields({
-                name: `${item.icon} ${item.name} ${canAfford ? '✅' : '❌'}`,
-                value: `**Giá:** ${currencyData.icon} ${item.price.toLocaleString()} ${currencyData.name}\n` +
-                       `**Có:** ${currencyData.icon} ${userHas.toLocaleString()}\n` +
-                       `**Mô tả:** ${item.description}\n` +
-                       `**Lệnh:** \`!shop buy ${id}\``,
-                inline: true
-            });
-        });
-        pages.push(pillsEmbed);
-
-        // Page 4: Linh dược và Sách
-        const medicineEmbed = new EmbedBuilder()
-            .setTitle('💚 Linh Dược & Sách Kỹ Thuật')
-            .setDescription('**Linh dược hồi phục sức khỏe và sách dạy võ công bí kíp**')
-            .setColor(0x44ddff)
-            .setTimestamp()
-            .setFooter({ 
-                text: `Trang 4/4 • ${message.author.username}`, 
-                iconURL: message.author.displayAvatarURL() 
-            });
-
-        // Add linh dược và sách
-        Object.entries(SHOP_ITEMS).filter(([id, item]) => 
-            id.startsWith('ly') || id.startsWith('book')
-        ).forEach(([id, item]) => {
-            // Handle items without price
-            if (!item.price || !item.currency) {
-                medicineEmbed.addFields({
-                    name: `${item.icon} ${item.name} 🚧`,
-                    value: `**Giá:** Chưa có giá (sắp ra mắt)\n` +
-                           `**Mô tả:** ${item.description}\n` +
-                           `**Trạng thái:** Đang phát triển`,
-                    inline: true
-                });
-                return;
-            }
-
-            const currencyData = SPIRIT_STONES[item.currency];
-            const userHas = userCurrency[item.currency] || 0;
-            const canAfford = userHas >= item.price;
-            
-            medicineEmbed.addFields({
-                name: `${item.icon} ${item.name} ${canAfford ? '✅' : '❌'}`,
-                value: `**Giá:** ${currencyData.icon} ${item.price.toLocaleString()} ${currencyData.name}\n` +
-                       `**Có:** ${currencyData.icon} ${userHas.toLocaleString()}\n` +
-                       `**Mô tả:** ${item.description}\n` +
-                       `**Lệnh:** \`!shop buy ${id}\``,
-                inline: true
-            });
-        });
-        pages.push(medicineEmbed);
 
         // Create navigation buttons
         const createButtons = (currentPage, totalPages) => {


### PR DESCRIPTION
Remove specified pages from `!shop` and `!craft` commands and fix an inventory display error.

The inventory error `Cannot read properties of undefined (reading 'icon')` occurred when displaying items if their `SHOP_ITEMS` entry lacked an `icon` property. The fix adds a null check for `shopData.icon` to prevent this.