### PR TITLE
Read and fix inventory command error

### DIFF
--- a/commands/cultivation/inventory.js
+++ b/commands/cultivation/inventory.js
@@ -8,10 +8,6 @@ module.exports = {
     examples: [
         '!inventory - Xem tất cả',
         '!inv @user - Xem của user khác', 
-        '!inv materials - Chỉ xem nguyên liệu',
-        '!inv medicines - Chỉ xem thuốc/đan dược',
-        '!inv stones - Chỉ xem linh thạch',
-        '!inv shop - Chỉ xem vật phẩm shop',
         '!zoo - Alias cũ vẫn hoạt động'
     ],
     permissions: 'everyone',
@@ -22,7 +18,6 @@ module.exports = {
         try {
             // Parse arguments
             let targetUser = message.author;
-            let filterType = 'all'; // 'all', 'materials', 'medicines', 'stones'
             
             // Check arguments
             for (const arg of args) {
@@ -40,14 +35,6 @@ module.exports = {
                             return message.reply('❌ Không tìm thấy user này!');
                         }
                     }
-                } else if (['materials', 'material', 'nguyen_lieu', 'nl', 'farm'].includes(arg.toLowerCase())) {
-                    filterType = 'materials';
-                } else if (['medicines', 'medicine', 'thuoc', 'med', 'drugs'].includes(arg.toLowerCase())) {
-                    filterType = 'medicines';
-                } else if (['stones', 'stone', 'linh_thach', 'lt', 'spirit'].includes(arg.toLowerCase())) {
-                    filterType = 'stones';
-                } else if (['shop', 'cua_hang', 'books', 'sach', 'linh_dan', 'ld', 'ly'].includes(arg.toLowerCase())) {
-                    filterType = 'shop';
                 }
             }
 
@@ -82,132 +69,124 @@ module.exports = {
             // Build response
             let responseText = `====== **${targetUser.username}'s Cultivation Inventory** ======\n`;
 
-            // Show materials if requested
-            if (filterType === 'all' || filterType === 'materials') {
-                responseText += `\n🌿 **NGUYÊN LIỆU FARM:**\n`;
-                
-                const materialDisplay = [];
-                let totalMaterials = 0;
-                
-                // Basic materials (1-7)
-                for (let i = 1; i <= 7; i++) {
-                    const material = materials.find(m => m.itemId === i.toString());
-                    const materialData = FARM_MATERIALS[i.toString()];
-                    const quantity = material ? material.quantity : 0;
-                    if (quantity > 0 && materialData && materialData.icon) {
-                        materialDisplay.push(`${materialData.icon}${quantity}`);
-                    } else if (quantity > 0 && materialData && materialData.fallbackIcon) {
-                        materialDisplay.push(`${materialData.fallbackIcon}${quantity}`);
-                    }
-                    totalMaterials += quantity;
+            // Show materials
+            responseText += `\n🌿 **NGUYÊN LIỆU FARM:**\n`;
+            
+            const materialDisplay = [];
+            let totalMaterials = 0;
+            
+            // Basic materials (1-7)
+            for (let i = 1; i <= 7; i++) {
+                const material = materials.find(m => m.itemId === i.toString());
+                const materialData = FARM_MATERIALS[i.toString()];
+                const quantity = material ? material.quantity : 0;
+                if (quantity > 0 && materialData && materialData.icon) {
+                    materialDisplay.push(`${materialData.icon}${quantity}`);
+                } else if (quantity > 0 && materialData && materialData.fallbackIcon) {
+                    materialDisplay.push(`${materialData.fallbackIcon}${quantity}`);
                 }
-                
-                // Special farmable materials (tlt, lt1)
-                ['tlt', 'lt1'].forEach(itemId => {
-                    const material = materials.find(m => m.itemId === itemId);
-                    const materialData = FARM_MATERIALS[itemId];
-                    const quantity = material ? material.quantity : 0;
-                    if (quantity > 0 && materialData && materialData.icon) {
-                        materialDisplay.push(`${materialData.icon}${quantity}`);
-                    } else if (quantity > 0 && materialData && materialData.fallbackIcon) {
-                        materialDisplay.push(`${materialData.fallbackIcon}${quantity}`);
-                    }
-                    totalMaterials += quantity;
-                });
-                
-                if (materialDisplay.length > 0) {
-                    responseText += materialDisplay.join(' ') + '\n';
-                } else {
-                    responseText += '🚫 Chưa có nguyên liệu nào! Dùng `!farm` để thu thập.\n';
+                totalMaterials += quantity;
+            }
+            
+            // Special farmable materials (tlt, lt1)
+            ['tlt', 'lt1'].forEach(itemId => {
+                const material = materials.find(m => m.itemId === itemId);
+                const materialData = FARM_MATERIALS[itemId];
+                const quantity = material ? material.quantity : 0;
+                if (quantity > 0 && materialData && materialData.icon) {
+                    materialDisplay.push(`${materialData.icon}${quantity}`);
+                } else if (quantity > 0 && materialData && materialData.fallbackIcon) {
+                    materialDisplay.push(`${materialData.fallbackIcon}${quantity}`);
                 }
+                totalMaterials += quantity;
+            });
+            
+            if (materialDisplay.length > 0) {
+                responseText += materialDisplay.join(' ') + '\n';
+            } else {
+                responseText += '🚫 Chưa có nguyên liệu nào! Dùng `!farm` để thu thập.\n';
             }
 
-            // Show medicines if requested
-            if (filterType === 'all' || filterType === 'medicines') {
-                responseText += `\n🧪 **THUỐC & ĐAN DƯỢC:**\n`;
-                
-                const medicineDisplay = [];
-                
-                // Không hiển thị thuốc cũ z series nữa
-                
-                // Đan dược (d series)
-                ['d1', 'd2', 'd3', 'd4'].forEach(medicineId => {
-                    const medicine = medicines.find(m => m.itemId === medicineId);
-                    const medicineData = MEDICINES[medicineId];
-                    const quantity = medicine ? medicine.quantity : 0;
-                    if (quantity > 0 && medicineData && medicineData.icon) {
-                        medicineDisplay.push(`${medicineData.icon}${quantity}`);
-                    }
-                });
-                
-                // Đan phương và đan lò (dp/dl series) - now farmable!
-                ['dp1', 'dp2', 'dp3', 'dp4', 'pdp', 'dl'].forEach(medicineId => {
-                    const medicine = medicines.find(m => m.itemId === medicineId);
-                    const medicineData = SHOP_ITEMS[medicineId]; // These are in SHOP_ITEMS, not MEDICINES
-                    const quantity = medicine ? medicine.quantity : 0;
-                    if (quantity > 0 && medicineData && medicineData.icon) {
-                        medicineDisplay.push(`${medicineData.icon}${quantity}`);
-                    } else if (quantity > 0 && medicineData && medicineData.fallbackIcon) {
-                        medicineDisplay.push(`${medicineData.fallbackIcon}${quantity}`);
-                    }
-                });
-
-                if (medicineDisplay.length > 0) {
-                    responseText += medicineDisplay.join(' ') + '\n';
-                } else {
-                    responseText += '🚫 Chưa có thuốc/đan dược nào! Dùng `!craft` hoặc `!farm` để thu thập.\n';
+            // Show medicines
+            responseText += `\n🧪 **THUỐC & ĐAN DƯỢC:**\n`;
+            
+            const medicineDisplay = [];
+            
+            // Không hiển thị thuốc cũ z series nữa
+            
+            // Đan dược (d series)
+            ['d1', 'd2', 'd3', 'd4'].forEach(medicineId => {
+                const medicine = medicines.find(m => m.itemId === medicineId);
+                const medicineData = MEDICINES[medicineId];
+                const quantity = medicine ? medicine.quantity : 0;
+                if (quantity > 0 && medicineData && medicineData.icon) {
+                    medicineDisplay.push(`${medicineData.icon}${quantity}`);
                 }
+            });
+            
+            // Đan phương và đan lò (dp/dl series) - now farmable!
+            ['dp1', 'dp2', 'dp3', 'dp4', 'pdp', 'dl'].forEach(medicineId => {
+                const medicine = medicines.find(m => m.itemId === medicineId);
+                const medicineData = SHOP_ITEMS[medicineId]; // These are in SHOP_ITEMS, not MEDICINES
+                const quantity = medicine ? medicine.quantity : 0;
+                if (quantity > 0 && medicineData && medicineData.icon) {
+                    medicineDisplay.push(`${medicineData.icon}${quantity}`);
+                } else if (quantity > 0 && medicineData && medicineData.fallbackIcon) {
+                    medicineDisplay.push(`${medicineData.fallbackIcon}${quantity}`);
+                }
+            });
+
+            if (medicineDisplay.length > 0) {
+                responseText += medicineDisplay.join(' ') + '\n';
+            } else {
+                responseText += '🚫 Chưa có thuốc/đan dược nào! Dùng `!craft` hoặc `!farm` để thu thập.\n';
             }
 
-            // Show spirit stones if requested
-            if (filterType === 'all' || filterType === 'stones') {
-                responseText += `\n💎 **LINH THẠCH (từ đột phá):**\n`;
-                
-                const stoneDisplay = [];
-                let totalStones = 0;
-                
-                // Check for spirit stones (stored with spirit_ prefix)
-                ['lt1', 'lt2', 'lt3', 'lt4'].forEach(stoneId => {
-                    const stone = spiritStones.find(s => s.itemId === `spirit_${stoneId}`);
-                    const stoneData = SPIRIT_STONES[stoneId];
-                    const quantity = stone ? stone.quantity : 0;
-                    if (quantity > 0 && stoneData && stoneData.icon) {
-                        stoneDisplay.push(`${stoneData.icon}${quantity}`);
-                        totalStones += quantity;
-                    } else if (quantity > 0 && stoneData && stoneData.fallbackIcon) {
-                        stoneDisplay.push(`${stoneData.fallbackIcon}${quantity}`);
-                        totalStones += quantity;
-                    }
-                });
-
-                if (stoneDisplay.length > 0) {
-                    responseText += stoneDisplay.join(' ') + '\n';
-                } else {
-                    responseText += '🚫 Chưa có linh thạch nào! Đột phá thành công để nhận linh thạch.\n';
+            // Show spirit stones
+            responseText += `\n💎 **LINH THẠCH (từ đột phá):**\n`;
+            
+            const stoneDisplay = [];
+            let totalStones = 0;
+            
+            // Check for spirit stones (stored with spirit_ prefix)
+            ['lt1', 'lt2', 'lt3', 'lt4'].forEach(stoneId => {
+                const stone = spiritStones.find(s => s.itemId === `spirit_${stoneId}`);
+                const stoneData = SPIRIT_STONES[stoneId];
+                const quantity = stone ? stone.quantity : 0;
+                if (quantity > 0 && stoneData && stoneData.icon) {
+                    stoneDisplay.push(`${stoneData.icon}${quantity}`);
+                    totalStones += quantity;
+                } else if (quantity > 0 && stoneData && stoneData.fallbackIcon) {
+                    stoneDisplay.push(`${stoneData.fallbackIcon}${quantity}`);
+                    totalStones += quantity;
                 }
+            });
+
+            if (stoneDisplay.length > 0) {
+                responseText += stoneDisplay.join(' ') + '\n';
+            } else {
+                responseText += '🚫 Chưa có linh thạch nào! Đột phá thành công để nhận linh thạch.\n';
             }
 
-            // Show shop items if requested (linh đan, linh dược, sách)
-            if (filterType === 'all' || filterType === 'shop') {
-                responseText += `\n🛍️ **VẬT PHẨM SHOP (mua bằng linh thạch):**\n`;
-                
-                const shopDisplay = [];
-                
-                // Check for shop items
-                shopItems.forEach(item => {
-                    const shopData = SHOP_ITEMS[item.itemId];
-                    if (shopData && shopData.icon && item.quantity > 0) {
-                        shopDisplay.push(`${shopData.icon}${item.quantity}`);
-                    } else if (shopData && shopData.fallbackIcon && item.quantity > 0) {
-                        shopDisplay.push(`${shopData.fallbackIcon}${item.quantity}`);
-                    }
-                });
-
-                if (shopDisplay.length > 0) {
-                    responseText += shopDisplay.join(' ') + '\n';
-                } else {
-                    responseText += '🚫 Chưa có vật phẩm shop nào! Dùng `!shop` để mua linh đan, linh dược và sách.\n';
+            // Show shop items (linh đan, linh dược, sách)
+            responseText += `\n🛍️ **VẬT PHẨM SHOP (mua bằng linh thạch):**\n`;
+            
+            const shopDisplay = [];
+            
+            // Check for shop items
+            shopItems.forEach(item => {
+                const shopData = SHOP_ITEMS[item.itemId];
+                if (shopData && shopData.icon && item.quantity > 0) {
+                    shopDisplay.push(`${shopData.icon}${item.quantity}`);
+                } else if (shopData && shopData.fallbackIcon && item.quantity > 0) {
+                    shopDisplay.push(`${shopData.fallbackIcon}${item.quantity}`);
                 }
+            });
+
+            if (shopDisplay.length > 0) {
+                responseText += shopDisplay.join(' ') + '\n';
+            } else {
+                responseText += '🚫 Chưa có vật phẩm shop nào! Dùng `!shop` để mua linh đan, linh dược và sách.\n';
             }
 
             // Add user stats
@@ -216,26 +195,12 @@ module.exports = {
             responseText += `• **EXP:** ${cultivationUser.exp}\n`;
 
             // Add helpful tips
-            if (filterType === 'all') {
-                responseText += `\n💡 **GỢI Ý:**\n`;
-                responseText += `• \`!inv materials\` - Chỉ xem nguyên liệu & linh thạch farm\n`;
-                responseText += `• \`!inv medicines\` - Chỉ xem thuốc & đan phương\n`;
-                responseText += `• \`!inv stones\` - Chỉ xem linh thạch cao cấp\n`;
-                responseText += `• \`!inv shop\` - Chỉ xem vật phẩm từ shop\n`;
-                responseText += `• \`!farm\` - Thu thập nguyên liệu, đan phương, linh thạch (10+ tùy VIP)\n`;
-                responseText += `• \`!shop\` - Mua linh đan, linh dược, sách bằng linh thạch\n`;
-                responseText += `• \`!craft recipes\` - Xem công thức chế tạo\n`;
-                responseText += `• \`!breakthrough\` - Đột phá để nhận linh thạch\n`;
-                responseText += `• **1 tin nhắn** = 1 EXP | **1 phút voice** = 5 EXP`;
-            } else if (filterType === 'materials') {
-                responseText += `\n💡 *Dùng \`!farm\` để thu thập nguyên liệu, đan lò, tụ linh thạch. Dùng \`!craft recipes\` để xem công thức.*`;
-            } else if (filterType === 'medicines') {
-                responseText += `\n💡 *Giờ có thể farm đan phương và đan lò! Dùng \`!farm\` để thu thập.*`;
-            } else if (filterType === 'stones') {
-                responseText += `\n💡 *Dùng \`!breakthrough\` để đột phá và \`!farm\` để thu thập tụ linh thạch craft*`;
-            } else if (filterType === 'shop') {
-                responseText += `\n💡 *Dùng \`!shop\` để mua linh đan, linh dược và sách. Dùng \`!shop buy <id>\` để mua.*`;
-            }
+            responseText += `\n💡 **GỢI Ý:**\n`;
+            responseText += `• \`!farm\` - Thu thập nguyên liệu, đan phương, linh thạch (10+ tùy VIP)\n`;
+            responseText += `• \`!shop\` - Mua linh đan, linh dược, sách bằng linh thạch\n`;
+            responseText += `• \`!craft recipes\` - Xem công thức chế tạo\n`;
+            responseText += `• \`!breakthrough\` - Đột phá để nhận linh thạch\n`;
+            responseText += `• **1 tin nhắn** = 1 EXP | **1 phút voice** = 5 EXP`;
 
             await message.reply(responseText);
 

--- a/commands/cultivation/inventory.js
+++ b/commands/cultivation/inventory.js
@@ -94,8 +94,10 @@ module.exports = {
                     const material = materials.find(m => m.itemId === i.toString());
                     const materialData = FARM_MATERIALS[i.toString()];
                     const quantity = material ? material.quantity : 0;
-                    if (quantity > 0) {
+                    if (quantity > 0 && materialData && materialData.icon) {
                         materialDisplay.push(`${materialData.icon}${quantity}`);
+                    } else if (quantity > 0 && materialData && materialData.fallbackIcon) {
+                        materialDisplay.push(`${materialData.fallbackIcon}${quantity}`);
                     }
                     totalMaterials += quantity;
                 }
@@ -105,8 +107,10 @@ module.exports = {
                     const material = materials.find(m => m.itemId === itemId);
                     const materialData = FARM_MATERIALS[itemId];
                     const quantity = material ? material.quantity : 0;
-                    if (quantity > 0) {
+                    if (quantity > 0 && materialData && materialData.icon) {
                         materialDisplay.push(`${materialData.icon}${quantity}`);
+                    } else if (quantity > 0 && materialData && materialData.fallbackIcon) {
+                        materialDisplay.push(`${materialData.fallbackIcon}${quantity}`);
                     }
                     totalMaterials += quantity;
                 });
@@ -131,7 +135,7 @@ module.exports = {
                     const medicine = medicines.find(m => m.itemId === medicineId);
                     const medicineData = MEDICINES[medicineId];
                     const quantity = medicine ? medicine.quantity : 0;
-                    if (quantity > 0) {
+                    if (quantity > 0 && medicineData && medicineData.icon) {
                         medicineDisplay.push(`${medicineData.icon}${quantity}`);
                     }
                 });
@@ -139,10 +143,12 @@ module.exports = {
                 // Đan phương và đan lò (dp/dl series) - now farmable!
                 ['dp1', 'dp2', 'dp3', 'dp4', 'pdp', 'dl'].forEach(medicineId => {
                     const medicine = medicines.find(m => m.itemId === medicineId);
-                    const medicineData = MEDICINES[medicineId];
+                    const medicineData = SHOP_ITEMS[medicineId]; // These are in SHOP_ITEMS, not MEDICINES
                     const quantity = medicine ? medicine.quantity : 0;
-                    if (quantity > 0) {
+                    if (quantity > 0 && medicineData && medicineData.icon) {
                         medicineDisplay.push(`${medicineData.icon}${quantity}`);
+                    } else if (quantity > 0 && medicineData && medicineData.fallbackIcon) {
+                        medicineDisplay.push(`${medicineData.fallbackIcon}${quantity}`);
                     }
                 });
 
@@ -165,8 +171,11 @@ module.exports = {
                     const stone = spiritStones.find(s => s.itemId === `spirit_${stoneId}`);
                     const stoneData = SPIRIT_STONES[stoneId];
                     const quantity = stone ? stone.quantity : 0;
-                    if (quantity > 0) {
+                    if (quantity > 0 && stoneData && stoneData.icon) {
                         stoneDisplay.push(`${stoneData.icon}${quantity}`);
+                        totalStones += quantity;
+                    } else if (quantity > 0 && stoneData && stoneData.fallbackIcon) {
+                        stoneDisplay.push(`${stoneData.fallbackIcon}${quantity}`);
                         totalStones += quantity;
                     }
                 });
@@ -189,6 +198,8 @@ module.exports = {
                     const shopData = SHOP_ITEMS[item.itemId];
                     if (shopData && shopData.icon && item.quantity > 0) {
                         shopDisplay.push(`${shopData.icon}${item.quantity}`);
+                    } else if (shopData && shopData.fallbackIcon && item.quantity > 0) {
+                        shopDisplay.push(`${shopData.fallbackIcon}${item.quantity}`);
                     }
                 });
 


### PR DESCRIPTION
Fix `!inv` command `TypeError` and simplify its usage by removing filter options.

The `TypeError` in the `!inv` command occurred because certain items (e.g., `dp1`, `dp2`) were incorrectly looked up in `MEDICINES` instead of `SHOP_ITEMS`, and due to missing null checks for `icon` properties across various inventory item types.